### PR TITLE
Linking the emulators/mame4all/roms directory to roms/mame4all

### DIFF
--- a/mame_install.py
+++ b/mame_install.py
@@ -43,15 +43,10 @@ mkdir /home/pi/pimame/emulators/mame4all-pi/
 cp mame4all-pi/mame4all_pi.zip /home/pi/pimame/emulators/mame4all-pi/
 cd /home/pi/pimame/emulators/mame4all-pi/
 unzip -o mame4all_pi.zip
-cd /home/pi/pimame/roms/
-mv mame4all mame4all-old
-ln -s /home/pi/pimame/emulators/mame4all-pi/roms /home/pi/pimame/roms/mame4all
-mv mame4all-old/* mame4all/
-rmdir mame4all-old
-
+rm -rf /home/pi/pimame/emulators/mame4all-pi/roms
+ln -s /home/pi/pimame/roms/mame4all /home/pi/pimame/emulators/mame4all-pi/roms
 cd /home/pi/pimame
 rm -rf mame4all-pi/
-
 ####MAME END#########
 cd /home/pi/pimame/pimame-menu/
 '''


### PR DESCRIPTION
Without doing so all ROMs were failing to load with
"ERROR: The required files are missing, the game cannot be run'"

I've added steps to mv any contents already within the roms/mame4all directory in-case a user had already placed ROMs there.

Not sure if this is the best way to tackle it, but it works for me.

Another option could be to update the path to the roms in the menu config.yaml?  I'm still yet to get my head around the intricacies of the menu and as such am not sure exactly why this was failing to begin with.
